### PR TITLE
fix rosdep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>nlohmann-json-dev</depend>
-  <depend>nlohmann_json_schema_validator</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
when run rosdep, following the setup instrcution of rmf. 
```
rosdep install --from-paths src --ignore-src --rosdistro galactic -y
```

will get error
```
nlohmann_json_schema_validator_vendor: Cannot locate rosdep definition for [nlohmann_json_schema_validator]
```

Thus remove the pkg `nlohmann_json_schema_validator` in `package.xml`