### PR TITLE
remove dependency since there's no package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>nlohmann-json-dev</depend>
-  <depend>nlohmann_json_schema_validator</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

## Bug fix

### Fixed bug

The package `nlohmann_json_schema_validator` is not available under ubuntu, which makes `rosdep` fail (unless you have the source code in your workspace) and more importantly the package building process in the buildfarm.

### Fix applied

Removed the `nlohmann_json_schema_validator` from the `package.xml` file.