### PR TITLE
Change install behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,15 +23,9 @@ if(NOT nlohmann_json_schema_validator_FOUND)
     URL https://github.com/pboettch/json-schema-validator/archive/refs/tags/2.1.0.zip
     URL_MD5 9542b03326e5a7ed8fdd6548192f9474
     CMAKE_ARGS
-      -DCMAKE_INSTALL_PREFIX=${setup_install_dir}
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
       -DBUILD_SHARED_LIBS=true
-    INSTALL_DIR ${setup_install_dir}
-  )
-
-  install(
-    DIRECTORY ${setup_install_dir}/
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
-    USE_SOURCE_PERMISSIONS
+    INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
   )
 endif()
 


### PR DESCRIPTION
The upstream `nlohmann_json_schema_validator` package does not do a relocatable installation, so the previous install pattern fails when built on the build farm where build directories are deleted after installation.

This PR changes the vendor script to instruct the upstream package to install directly to the install directory instead of installing to a build directory and then relocating it.