### PR TITLE
Remove export of vendored project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.5)
 project(nlohmann_json_schema_validator_vendor)
 
 find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_libraries REQUIRED)
 
 macro(build_nlohmann_json_schema_validator)
 
@@ -88,10 +87,6 @@ macro(build_nlohmann_json_schema_validator)
 endmacro()
 
 build_nlohmann_json_schema_validator()
-
-ament_export_include_directories(include)
-ament_export_libraries(nlohmann_json_schema_validator)
-ament_export_dependencies(nlohmann_json_schema_validator)
 
 # this ensures that the package has an environment hook setting the PATH
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,6 @@
   <license>MIT License</license> <!-- nlohmann json schema validator is MIT License -->
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_libraries</buildtool_depend>
   <buildtool_depend>git</buildtool_depend>
 
   <depend>nlohmann-json-dev</depend>

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_libraries</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <depend>nlohmann-json-dev</depend>
 


### PR DESCRIPTION
ament's dependency export system relies on adding corresponding exported dependencies in the `package.xml` file.

It actually would be possible to use this export if an additional `buildtool_export_depend` on `ament_cmake` was used so that all downstream packages required `ament_cmake` to build using this package.

However, that's a bit heavy handed for a vendor package in particular and it is a recommended practice that vendor packages be as transparent as possible so that they can be removed once deprecated.

This change will require updates to packages consuming this vendor package.

---

An additional change updates the package.xml to reflect that `git` is a required build tool when fetching git repositories using `externalproject_add`.