### PR TITLE
Sync main with latest fix for humble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog for package nlohmann_json_schema_validator_vendor
 
+0.2.4 (2022-11-28)
+------------------
+* Added patch command and file to try to fix the version problem.
+* Contributors: Esteban Martinena
+
 0.2.3 (2022-11-15)
 ------------------
 * Fixed external project commit reference to build with json-dev 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog for package nlohmann_json_schema_validator_vendor
 
+0.2.3 (2022-11-15)
+------------------
+* Fixed external project commit reference to build with json-dev 3.6
+
 0.2.2 (2022-11-14)
 ------------------
 * Vendoring a version that not depends on json-dev > 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog for package nlohmann_json_schema_validator_vendor
 
+0.2.2 (2022-11-14)
+------------------
+* Vendoring a version that not depends on json-dev > 3.6
+  [https://github.com/open-rmf/rmf/issues/265#validator](https://github.com/open-rmf/rmf/issues/265#validator)
+* Contributors: Esteban Martinena
+
 0.2.1 (2022-10-09)
 ------------------
 * Remove export of vendored project. [#10](https://github.com/open-rmf/nlohmann_json_schema_validator_vendor/issues/10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ macro(build_nlohmann_json_schema_validator)
   set(json_external_project_dir ${CMAKE_CURRENT_BINARY_DIR}/json_external_project)
   include(ExternalProject)
   # HEAD of `main` branch on 2022-10-07
-  set(nlohmann_json_schema_validator_version "5782bdcf9ebbc552a4a6f899f8e50ed7181f397c")
+  set(nlohmann_json_schema_validator_version "5ef4f903af055550e06955973a193e17efded896")
   externalproject_add(nlohmann_json_schema_validator-${nlohmann_json_schema_validator_version}
     GIT_REPOSITORY https://github.com/pboettch/json-schema-validator.git
     GIT_TAG ${nlohmann_json_schema_validator_version}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ macro(build_nlohmann_json_schema_validator)
   set(json_external_project_dir ${CMAKE_CURRENT_BINARY_DIR}/json_external_project)
   include(ExternalProject)
   # HEAD of `main` branch on 2022-10-07
-  set(nlohmann_json_schema_validator_version "1063c9adbafc25f5a14bae15c3babdb039de86c6")
+  set(nlohmann_json_schema_validator_version "5782bdcf9ebbc552a4a6f899f8e50ed7181f397c")
   externalproject_add(nlohmann_json_schema_validator-${nlohmann_json_schema_validator_version}
     GIT_REPOSITORY https://github.com/pboettch/json-schema-validator.git
     GIT_TAG ${nlohmann_json_schema_validator_version}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ macro(build_nlohmann_json_schema_validator)
     # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
     UPDATE_COMMAND ""
     TIMEOUT 6000
+    PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/patch_cmakelist
     ${cmake_commands}
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${json_external_project_dir}/install/

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>nlohmann_json_schema_validator_vendor</name>
-  <version>0.2.2</version>
+  <version>0.2.3</version>
   <description>A vendor package for JSON schema validator for JSON for Modern C++</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <license>Apache License 2.0</license> <!-- the contents of this package are Apache 2.0 -->

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>nlohmann_json_schema_validator_vendor</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>A vendor package for JSON schema validator for JSON for Modern C++</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <license>Apache License 2.0</license> <!-- the contents of this package are Apache 2.0 -->

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>nlohmann_json_schema_validator_vendor</name>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
   <description>A vendor package for JSON schema validator for JSON for Modern C++</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <license>Apache License 2.0</license> <!-- the contents of this package are Apache 2.0 -->

--- a/patch_cmakelist
+++ b/patch_cmakelist
@@ -1,0 +1,62 @@
+--- ./CMakeLists.txt
++++ ./CMakeLists.txt
+@@ -156,34 +156,33 @@
+ endif()
+ 
+ if(JSON_VALIDATOR_INSTALL)
+-    # Set Up the Project Targets and Config Files for CMake
+-
+-    # Set the install path to the cmake config files
+-    set(INSTALL_CMAKE_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/${PROJECT_NAME})
+-
+-    # Create the ConfigVersion file
+-    include(CMakePackageConfigHelpers) # write_basic_package_version_file
+-    write_basic_package_version_file( ${PROJECT_NAME}ConfigVersion.cmake
+-                                      VERSION ${PACKAGE_VERSION}
+-                                      COMPATIBILITY SameMajorVersion)
+-
+-    # Get the relative path from the INSTALL_CMAKE_DIR to the include directory
+-    file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}" "${CMAKE_INSTALL_PREFIX}/include")
+-
+-
+-    # Configure the Config.cmake file with the proper include directory
+-    set(CONF_INCLUDE_DIRS "\${JSON_SCHEMA_VALIDATOR_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+-    configure_file(${PROJECT_NAME}Config.cmake.in
+-                   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" @ONLY)
+-
+-    # Install the Config.cmake and ConfigVersion.cmake files
+-    install(FILES
+-            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+-            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+-            DESTINATION "${INSTALL_CMAKE_DIR}")
++    # Set the install path to the cmake config files (Relative, so install works correctly under Hunter as well)
++    set(INSTALL_CMAKE_DIR "lib/cmake/${PROJECT_NAME}")
++    set(INSTALL_CMAKEDIR_ROOT share/cmake)
+ 
+     # Install Targets
+     install(EXPORT ${PROJECT_NAME}Targets
+             FILE ${PROJECT_NAME}Targets.cmake
+             DESTINATION "${INSTALL_CMAKE_DIR}")
++
++    include(CMakePackageConfigHelpers)
++    write_basic_package_version_file(
++        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
++        VERSION ${PROJECT_VERSION}
++        COMPATIBILITY SameMajorVersion
++        )
++
++    configure_package_config_file(
++        ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}Config.cmake.in
++        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
++        INSTALL_DESTINATION ${INSTALL_CMAKEDIR_ROOT}/${PROJECT_NAME}
++        )
++
++    install(
++        FILES
++            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
++            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
++        DESTINATION
++            ${INSTALL_CMAKE_DIR}
++        )
+ endif()
+


### PR DESCRIPTION
We needed to downgrade the version we are using of nlohmann_json_schema_validator to one that not depends on nlohmann_json > 3.6
We also needed to patch the CMakeList to make the installation redistributable.